### PR TITLE
Fix answers to Q41 and Q45

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,8 @@ Download the kubeconfig file from your cluster and configure kubectl to use it.
             imagePullPolicy: Always
             name: nginx
           affinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
                 nodeSelectorTerms:
                 - matchExpressions:
                   - key: color
@@ -591,9 +592,9 @@ Download the kubeconfig file from your cluster and configure kubectl to use it.
 
     [RBAC documentation](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
 
-        kubectl create serviceaccount pvviewer-practice
-        kubectl create clusterrole pvviewr-role-practice --resource=pv --verb=list
-        kubectl create clusterrolebinding pvviewer-role-binding-practice --clusterrole=pvviewr-role-practice --serviceaccount=default:pvviewer-practice
+        kubectl -n practice create serviceaccount pvviewer-practice
+        kubectl -n practice create clusterrole pvviewer-role-practice --resource=pv --verb=list
+        kubectl -n practice create clusterrolebinding pvviewer-role-binding-practice --clusterrole=pvviewer-role-practice --serviceaccount=practice:pvviewer-practice
 
     **Take-away**: Read the documentation and try to understand more for Role, ClusterRole, RoleBinding and ClusterRoleBinding.
 
@@ -646,7 +647,7 @@ Download the kubeconfig file from your cluster and configure kubectl to use it.
     spec:
       podSelector:
         matchLabels:
-          run: nginx-last # selector for the pods
+          app: nginx-last # selector for the pods
       ingress:            # allow ingress traffic
       - from:
         - podSelector:    # from pods

--- a/README.md
+++ b/README.md
@@ -337,8 +337,7 @@ Download the kubeconfig file from your cluster and configure kubectl to use it.
             imagePullPolicy: Always
             name: nginx
           affinity:
-            nodeAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
+            requiredDuringSchedulingIgnoredDuringExecution:
                 nodeSelectorTerms:
                 - matchExpressions:
                   - key: color


### PR DESCRIPTION
- ~~Q22: fixed node affinity per [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core) and [examples](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/#schedule-a-pod-using-required-node-affinity)~~
- Q41: per Q1 all commands should be run in `practice` namespace unless task says otherwise, fixed typo in ClusterRole name
- Q45: `kubectl create deployment` adds `app` label to the pods